### PR TITLE
Add regex functionality,  and calculate a default value for width in `fitb` function

### DIFF
--- a/R/webex_fns.R
+++ b/R/webex_fns.R
@@ -5,11 +5,12 @@
 #' @param num whether the input is numeric, in which case allow for leading zeroes to be omitted
 #' @param ignore_case Whether to ignore case (capitalization)
 #' @param ignore_ws Whether to ignore white space
+#' @param regex Whether to use regex to match answers (concatenates all answers with `|` before matching)
 #' @details Writes html code that creates an input box widget. Call this function inline in an RMarkdown document. See the Web Exercises RMarkdown template for examples.
 #' @export
 fitb <- function(answer, width = 3, num = FALSE,
                  ignore_case = FALSE,
-                 ignore_ws = TRUE) {
+                 ignore_ws = TRUE, regex=FALSE) {
   if (num) {
     answer2 <- strip_lzero(answer)
     answer <- union(answer, answer2)
@@ -18,6 +19,7 @@ fitb <- function(answer, width = 3, num = FALSE,
   paste0("<input class='solveme",
          ifelse(ignore_ws, " nospaces", ""),
          ifelse(ignore_case, " ignorecase", ""),
+         ifelse(regex, " regex", ""),
          "' size='", width,
          "' data-answer='", answers, "'/>")
 }

--- a/R/webex_fns.R
+++ b/R/webex_fns.R
@@ -1,20 +1,24 @@
 #' Create fill-in-the-blank question
 #'
 #' @param answer The correct answer
-#' @param width Width of the input box in characters
+#' @param width Width of the input box in characters. Defaults to the length of the longest answer.
 #' @param num whether the input is numeric, in which case allow for leading zeroes to be omitted
 #' @param ignore_case Whether to ignore case (capitalization)
 #' @param ignore_ws Whether to ignore white space
 #' @param regex Whether to use regex to match answers (concatenates all answers with `|` before matching)
 #' @details Writes html code that creates an input box widget. Call this function inline in an RMarkdown document. See the Web Exercises RMarkdown template for examples.
 #' @export
-fitb <- function(answer, width = 3, num = FALSE,
+fitb <- function(answer, width = calculated_width, num = FALSE,
                  ignore_case = FALSE,
                  ignore_ws = TRUE, regex=FALSE) {
   if (num) {
     answer2 <- strip_lzero(answer)
     answer <- union(answer, answer2)
   }
+  
+  # if width not set, calculate it from max length answer, up to limit of 100
+  calculated_width <- min(100, max(purrr::map_int(answer, nchar)))
+  
   answers <- jsonlite::toJSON(as.character(answer))
   paste0("<input class='solveme",
          ifelse(ignore_ws, " nospaces", ""),

--- a/R/webex_fns.R
+++ b/R/webex_fns.R
@@ -3,14 +3,23 @@
 #' @param answer The correct answer
 #' @param width Width of the input box in characters. Defaults to the length of the longest answer.
 #' @param num whether the input is numeric, in which case allow for leading zeroes to be omitted
+#' @param tol the tolerance within which numeric answers will be accepts; i.e. (response - true.answer) < tol = a correct response. Implies num=TRUE
 #' @param ignore_case Whether to ignore case (capitalization)
 #' @param ignore_ws Whether to ignore white space
 #' @param regex Whether to use regex to match answers (concatenates all answers with `|` before matching)
 #' @details Writes html code that creates an input box widget. Call this function inline in an RMarkdown document. See the Web Exercises RMarkdown template for examples.
 #' @export
-fitb <- function(answer, width = calculated_width, num = FALSE,
+fitb <- function(answer, width = calculated_width, 
+                 num = FALSE,
                  ignore_case = FALSE,
+                 tol=NULL,
                  ignore_ws = TRUE, regex=FALSE) {
+  
+  
+  if(!is.null(tol)){
+    num <- TRUE
+  } 
+
   if (num) {
     answer2 <- strip_lzero(answer)
     answer <- union(answer, answer2)
@@ -22,6 +31,7 @@ fitb <- function(answer, width = calculated_width, num = FALSE,
   answers <- jsonlite::toJSON(as.character(answer))
   paste0("<input class='solveme",
          ifelse(ignore_ws, " nospaces", ""),
+         ifelse(!is.null(tol), paste0("' data-tol='", tol, ""), ""),
          ifelse(ignore_case, " ignorecase", ""),
          ifelse(regex, " regex", ""),
          "' size='", width,

--- a/inst/rmarkdown/templates/webex/skeleton/webex.js
+++ b/inst/rmarkdown/templates/webex/skeleton/webex.js
@@ -36,6 +36,15 @@ solveme_func = function(e) {
   } else {
     cl.remove("correct");
   }
+
+  // added regex bit
+  if (cl.contains("regex")){
+    answer_regex = RegExp(real_answers.join("|"))
+    if (answer_regex.test(my_answer)) {
+      cl.add("correct");
+    }  
+  }
+  
   update_total_correct();
 }
 

--- a/inst/rmarkdown/templates/webex/skeleton/webex.js
+++ b/inst/rmarkdown/templates/webex/skeleton/webex.js
@@ -37,6 +37,17 @@ solveme_func = function(e) {
     cl.remove("correct");
   }
 
+  // match numeric answers within a specified tolerance
+  if(this.dataset.tol){
+    var tol = JSON.parse(this.dataset.tol);  
+    var matches = real_answers.map(x => Math.abs(x - my_answer) < tol)
+    if (matches.reduce((a, b) => a + b, 0) > 0) {
+      cl.add("correct");
+    } else {
+      cl.remove("correct");
+    }  
+  }
+
   // added regex bit
   if (cl.contains("regex")){
     answer_regex = RegExp(real_answers.join("|"))


### PR DESCRIPTION
Thanks for webex it's proving very useful.
I've made some minor tweaks in my fork so thought I would share. Apologies for not splitting this into two PR's, but I create a branch and cherry pick if needed...

The changes here:

- Allow `fitb` to accept regex answers, if setting the `regex` argument to `TRUE`
- Remove the default `width=3` param, and replace it with a calculated parameter, which defaults to the length of the longest answer (with a max of 100).


